### PR TITLE
Navbar width match layout

### DIFF
--- a/src/components/layouts/navbar/navbar.tsx
+++ b/src/components/layouts/navbar/navbar.tsx
@@ -21,7 +21,7 @@ const Navbar: FC<NavBarProps> = ({ navItems }) => {
             bg={useColorModeValue("#ffffff80", "#30303890")}
             style={{ backdropFilter: "blur(10px)" }}
         >
-            <Container display="flex" p={2} maxW="container.md" wrap="wrap" align="center" justify="space-between">
+            <Container display="flex" p={2} maxW="container.xl" wrap="wrap" align="center" justify="space-between">
                 <Flex align="center" mr={5}>
                     <Heading as="h1" size="lg" letterSpacing={"tighter"}>
                         <Logo />


### PR DESCRIPTION
Navbaren var mindre end layoutet, som så underligt ud. Nu er den ligeså bred som alt det andet

Før: 
![image](https://user-images.githubusercontent.com/15074677/145195032-9490b4c8-0462-4941-808f-5aaef58320d9.png)

Efter: 
![image](https://user-images.githubusercontent.com/15074677/145195413-b5289ded-3001-4924-a5b5-23934c56f4be.png)
